### PR TITLE
Update xPro offered_by to match the standard value

### DIFF
--- a/podcasts/mitxpro.yaml
+++ b/podcasts/mitxpro.yaml
@@ -1,4 +1,4 @@
 ---
 rss_url: http://mitxpro.libsyn.com/rss
-offered_by: xPRO
+offered_by: xPro
 website: http://mitxpro.libsyn.com/


### PR DESCRIPTION
Updates the configuration to match the constant defined in open so they don't get their own offered by  option, see screenshot:

![Screenshot_2020-05-21 MIT Open Learning](https://user-images.githubusercontent.com/28598/82588987-8268d080-9b69-11ea-95d1-64d3cf3055d8.png)
