### PR TITLE
add business topic to Sports Analytics podcast

### DIFF
--- a/podcasts/mit-sloan-sports-analytics-conference.yaml
+++ b/podcasts/mit-sloan-sports-analytics-conference.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feed.podbean.com/ssac/feed.xml
-topics: Physical Education and Recreation
+topics: Physical Education and Recreation, Business
 offered_by: Sloan School of Management
 website: http://www.sloansportsconference.com/
 


### PR DESCRIPTION
I noticed on the podcast page that this podcast has only one topic. 