### PR TITLE
remove non-MIT podcasts 

### DIFF
--- a/podcasts/broad-ignite.yaml
+++ b/podcasts/broad-ignite.yaml
@@ -1,5 +1,0 @@
----
-rss_url: http://feeds.soundcloud.com/users/soundcloud:users:241766132/sounds.rss
-topics: Science, Biology
-offered_by: Broad Inistitute
-website: https://soundcloud.com/broadignitepodcast

--- a/podcasts/lex-fridman.yaml
+++ b/podcasts/lex-fridman.yaml
@@ -1,5 +1,0 @@
----
-rss_url: https://lexfridman.com/category/ai/feed/
-topics: Computer Science
-website: https://lexfridman.com/
-

--- a/podcasts/mit-catalysts.yaml
+++ b/podcasts/mit-catalysts.yaml
@@ -1,5 +1,0 @@
----
-rss_url: https://feeds.buzzsprout.com/615046.rss
-topics: Business, Entrepreneurship
-website: https://www.mitcnc.org/podcasts/
-

--- a/podcasts/mit-club-of-boston.yaml
+++ b/podcasts/mit-club-of-boston.yaml
@@ -1,5 +1,0 @@
----
-rss_url: https://feeds.buzzsprout.com/707100.rss
-topics: Teaching and Education, Business
-website: http://boston.alumclub.mit.edu/
-

--- a/podcasts/mit-enterprise-forum.yaml
+++ b/podcasts/mit-enterprise-forum.yaml
@@ -1,5 +1,0 @@
----
-rss_url: https://www.mitforumcambridge.org/podcast/
-topics: Business, Teaching and Education
-website: https://www.mitforumcambridge.org/category/podcast/
-

--- a/podcasts/sloanies-talking-with-sloanies.yaml
+++ b/podcasts/sloanies-talking-with-sloanies.yaml
@@ -1,6 +1,0 @@
----
-rss_url: https://feeds.buzzsprout.com/489586.rss
-topics: Business, Teaching and Education
-offered_by: Sloan School of Management
-website: https://mitsloan.mit.edu/alumni/sloanies-talking-sloanies
-

--- a/podcasts/tech-review-business-lab.yaml
+++ b/podcasts/tech-review-business-lab.yaml
@@ -1,5 +1,0 @@
----
-rss_url: https://feeds.megaphone.fm/business-lab
-topics: Business, Computer Science
-offered_by: MIT Technology Review
-website: https://www.technologyreview.com/podcast/business-lab/

--- a/podcasts/tech-review_deeptech.yaml
+++ b/podcasts/tech-review_deeptech.yaml
@@ -1,7 +1,0 @@
----
-rss_url: https://feeds.megaphone.fm/deep-tech
-topics: Business, Computer Science
-offered_by: MIT Technology Review
-website: https://www.technologyreview.com/
-
-


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->

removes 
- Lex Friedman (personal podcast),
- Broad Institute (not MIT based on their domain (?))
- Techreview (not MIT (?))
- Enterprise forum  (not MIT https://theeforum.org/our-history/)
- Alums  (not MIT)

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Merge it, wait for the update task and then take a look at https://open.mit.edu/podcasts/

