### PR TITLE
switch from Apple podcast topics to MIT Learn topics

### DIFF
--- a/podcasts/biogenesis.yaml
+++ b/podcasts/biogenesis.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: http://feeds.soundcloud.com/users/soundcloud:users:695071844/sounds.rss
-topics: Science
+topics: Biology
 offered_by: Department of Biology
 website: https://biology.mit.edu/news/biogenesis-podcast/
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/biogenesis/id1478910563

--- a/podcasts/brave-new-planet.yaml
+++ b/podcasts/brave-new-planet.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feeds.megaphone.fm/bravenewplanet
-topics: Science
+topics: Science & Math,Engineering
 offered_by: Broad Institute
 website: https://www.pushkin.fm/show/brave-new-planet/
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/brave-new-planet/id1531898121

--- a/podcasts/chalk-radio.yaml
+++ b/podcasts/chalk-radio.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feeds.simplecast.com/8fQdS6Dx
-topics: Teaching and Education
+topics: Pedagogy and Curriculum, Digital Learning
 offered_by: OCW
 website: https://chalk-radio.simplecast.com/
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/chalk-radio/id1497545103

--- a/podcasts/curious_coincidence.yaml
+++ b/podcasts/curious_coincidence.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feeds.megaphone.fm/curiouscoincidence
-topics: Science,Technology
+topics: Science & Math,Engineering
 offered_by: MIT Technology Review
 website: https://www.technologyreview.com/supertopic/curious-coincidence/
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/curious-coincidence/id1609482049

--- a/podcasts/data-made-to-matter.yaml
+++ b/podcasts/data-made-to-matter.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: http://feeds.soundcloud.com/users/soundcloud:users:308863455/sounds.rss
-topics: Business
+topics: Business Analytics,Data Science
 offered_by: Sloan School of Management
 website: https://mitsloan.mit.edu/podcast
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cDovL2ZlZWRzLnNvdW5kY2xvdWQuY29tL3VzZXJzL3NvdW5kY2xvdWQ6dXNlcnM6MzA4ODYzNDU1L3NvdW5kcy5yc3M

--- a/podcasts/digital_transformation_journey.yaml
+++ b/podcasts/digital_transformation_journey.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://us.ivoox.com/es/feed_fg_f1908594_filtro_1.xml
-topics: Technology
+topics: Digital Business & IT
 website: https://us.ivoox.com/es/podcast-the-digital-transformation-journey_sq_f1908594_1.html
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/the-digital-transformation-journey/id1522273676
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly91cy5pdm9veC5jb20vZXMvZXNwb2RjYXN0LXRoZS1kaWdpdGFsLXRyYW5zZm9ybWF0aW9uLWpvdXJuZXlfZmdfZjE5MDg1OTRfZmlsdHJvXzEueG1s

--- a/podcasts/energy-reads.yaml
+++ b/podcasts/energy-reads.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://anchor.fm/s/994e642c/podcast/rss
-topics: Science
+topics: Energy
 offered_by: MIT Energy Initiative
 website: https://energy.mit.edu/audio
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly9hbmNob3IuZm0vcy85OTRlNjQyYy9wb2RjYXN0L3Jzcw

--- a/podcasts/glimpse.yaml
+++ b/podcasts/glimpse.yaml
@@ -1,7 +1,7 @@
   
 ---
 rss_url: http://glimpsepod.scripts.mit.edu/home/feed/podcast/
-topics: Science,Teaching and Education
+topics: Science & Math,Engineering 
 website: http://glimpse.mit.edu/
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/glimpse-podcast/id1048620479
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly9nbGltcHNlcG9kLnNjcmlwdHMubWl0LmVkdS9ob21lL2ZlZWQvcG9kY2FzdC8

--- a/podcasts/jpal-voices.yaml
+++ b/podcasts/jpal-voices.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feeds.simplecast.com/7xNsi2o4
-topics: Political Science,Social Science,Society
+topics: Political Science,Economics
 offered_by: J-PAL North America
 website: https://www.povertyactionlab.org/page/j-pal-voices-impact-and-promise-summer-jobs-united-states
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy5zaW1wbGVjYXN0LmNvbS83eE5zaTJvNA==

--- a/podcasts/jwel.yaml
+++ b/podcasts/jwel.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: http://feeds.soundcloud.com/users/soundcloud:users:499950009/sounds.rss
-topics: Teaching and Education
+topics: Digital Learning,Pedagogy and Curriculum
 offered_by: Open Learning
 website: https://soundcloud.com/jwel-wpl-podcast
 

--- a/podcasts/lock-the-quill.yaml
+++ b/podcasts/lock-the-quill.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feeds.buzzsprout.com/2074298.rss
-topics: Technology
+topics: Mechanical Engineering
 website: https://lockthequill.buzzsprout.com/
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/lock-the-quill/id1651986630
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy5idXp6c3Byb3V0LmNvbS8yMDc0Mjk4LnJzcw==

--- a/podcasts/me-myself-ai.yaml
+++ b/podcasts/me-myself-ai.yaml
@@ -1,5 +1,6 @@
 ---
 rss_url: https://memyselfandai.libsyn.com/rss
+topics: AI
 website: https://mitsmr.com/3co75FC
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly9tZW15c2VsZmFuZGFpLmxpYnN5bi5jb20vcnNz
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/me-myself-and-ai/id1533115958

--- a/podcasts/misti-radio.yaml
+++ b/podcasts/misti-radio.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://anchor.fm/s/1d2e1310/podcast/rss
 website: https://anchor.fm/misti-comm
-topics: Society
+topics: Science & Math,Engineering
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly9hbmNob3IuZm0vcy8xZDJlMTMxMC9wb2RjYXN0L3Jzcw==
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/misti-radio/id1512812329

--- a/podcasts/mit-bootcamps.yaml
+++ b/podcasts/mit-bootcamps.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: http://feeds.soundcloud.com/users/soundcloud:users:206634915/sounds.rss
-topics: Entrepreneurship,Teaching and Education
+topics: Entrepreneurship,Innovation Process
 offered_by: Bootcamps
 website: https://bootcamp.mit.edu/
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cDovL2ZlZWRzLnNvdW5kY2xvdWQuY29tL3VzZXJzL3NvdW5kY2xvdWQ6dXNlcnM6MjA2NjM0OTE1L3NvdW5kcy5yc3M

--- a/podcasts/mit-cisr.yaml
+++ b/podcasts/mit-cisr.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: http://feeds.soundcloud.com/users/soundcloud:users:443037198/sounds.rss
-topics: Business
+topics: Digital Business & IT
 offered_by: MIT Center for Information Systems Research
 website: https://cisr.mit.edu/research-library?sort=date&view=list&filters=1&pub_type%5B0%5D=12
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy5zb3VuZGNsb3VkLmNvbS91c2Vycy9zb3VuZGNsb3VkOnVzZXJzOjQ0MzAzNzE5OC9zb3VuZHMucnNz

--- a/podcasts/mit-cms.yaml
+++ b/podcasts/mit-cms.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: http://feeds.soundcloud.com/users/soundcloud:users:32571882/sounds.rss
-topics: Teaching and Education,Communication
+topics: Communication
 offered_by: School of Humanities, Arts, and Social Sciences
 website: https://cmsw.mit.edu/category/media/podcasts/
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cDovL2ZlZWRzLnNvdW5kY2xvdWQuY29tL3VzZXJzL3NvdW5kY2xvdWQ6dXNlcnM6MzI1NzE4ODIvc291bmRzLnJzcw

--- a/podcasts/mit-lgo_playbook.yaml
+++ b/podcasts/mit-lgo_playbook.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: http://feeds.soundcloud.com/users/soundcloud:users:561805800/sounds.rss
-topics: Business,Computer Science
+topics: Organizations & Leadership,Operations
 offered_by: MIT LGO
 website: https://lgo.mit.edu/
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cDovL2ZlZWRzLnNvdW5kY2xvdWQuY29tL3VzZXJzL3NvdW5kY2xvdWQ6dXNlcnM6NTYxODA1ODAwL3NvdW5kcy5yc3M

--- a/podcasts/mit-medical.yaml
+++ b/podcasts/mit-medical.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: http://feeds.feedburner.com/MITMedical
-topics: Health and Medicine
+topics: Public Health,Mental Health
 offered_by: MIT Medical
 website: https://medical.mit.edu/podcast
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cDovL2ZlZWRzLmZlZWRidXJuZXIuY29tL01JVE1lZGljYWw

--- a/podcasts/mit-supply-chain-frontiers.yaml
+++ b/podcasts/mit-supply-chain-frontiers.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feed.podbean.com/mitsupplychainfrontiers/feed.xml
-topics: Business
+topics: Supply Chain
 offered_by: Center for Transportation & Logistics
 website: https://ctl.mit.edu/podcasts
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/mit-supply-chain-frontiers/id1509776693

--- a/podcasts/mitnews-curiosity-unbounded.yaml
+++ b/podcasts/mitnews-curiosity-unbounded.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feeds.blubrry.com/feeds/1474794.xml
-topics: Science
+topics: Science & Math,Engineering
 offered_by: MIT News
 website: https://news.mit.edu/podcasts/curiosity-unbounded
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/curiosity-unbounded/id1692410948

--- a/podcasts/mitnews.yaml
+++ b/podcasts/mitnews.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feeds.blubrry.com/feeds/1474795.xml
-topics: Science
+topics: Science & Math,Engineering
 offered_by: MIT News
 website: https://news.mit.edu/podcasts/mit-news
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy5ibHVicnJ5LmNvbS9mZWVkcy8xNDc0Nzk1LnhtbA

--- a/podcasts/mitpress.yaml
+++ b/podcasts/mitpress.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feed.podbean.com/mitpress/feed.xml
-topics: Science,Teaching and Education
+topics: Literature
 offered_by: MIT Press
 website: https://mitpress.mit.edu/podcasts
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly9taXRwcmVzcy5wb2RiZWFuLmNvbS9mZWVkLnhtbA

--- a/podcasts/mitxpro.yaml
+++ b/podcasts/mitxpro.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: http://mitxpro.libsyn.com/rss
-topics: Business,Teaching and Education
+topics: AI,Systems Engineering
 offered_by: xPRO
 website: http://mitxpro.libsyn.com/
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly9taXR4cHJvLmxpYnN5bi5jb20vcnNz

--- a/podcasts/slice-of-mit.yaml
+++ b/podcasts/slice-of-mit.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: http://feeds.soundcloud.com/users/soundcloud:users:77918350/sounds.rss
-topics: Teaching and Education
+topics: Science & Math,Engineering
 offered_by: MIT Alumni
 website: https://alum.mit.edu/topic/podcast
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cDovL2ZlZWRzLnNvdW5kY2xvdWQuY29tL3VzZXJzL3NvdW5kY2xvdWQ6dXNlcnM6Nzc5MTgzNTAvc291bmRzLnJzcw

--- a/podcasts/teachlab.yaml
+++ b/podcasts/teachlab.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feeds.simplecast.com/SOC3TXff
-topics: Teaching and Education
+topics: Pedagogy and Curriculum,Digital Learning
 offered_by: Open Learning
 website: https://teachlabpodcast.com/
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy5zaW1wbGVjYXN0LmNvbS9TT0MzVFhmZg

--- a/podcasts/three-big-points.yaml
+++ b/podcasts/three-big-points.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: http://threebigpoints.libsyn.com/rss
-topics: Business,Management
+topics: Management
 offered_by: Sloan School of Management
 website: https://sloanreview.mit.edu/audio-series/three-big-points/
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/three-big-points/id1477875094

--- a/podcasts/trashtalking.yaml
+++ b/podcasts/trashtalking.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feed.podbean.com/trashtalkingpodcast/feed.xml
-topics: Physical Education and Recreation, Business
+topics: Management
 offered_by: Sloan School of Management
 website: http://www.sloansportsconference.com/
 google_podcasts_url: https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkLnBvZGJlYW4uY29tL3RyYXNodGFsa2luZ3BvZGNhc3QvZmVlZC54bWw

--- a/podcasts/trust-the-process-mit.yaml
+++ b/podcasts/trust-the-process-mit.yaml
@@ -1,6 +1,6 @@
 ---
 rss_url: https://feeds.captivate.fm/trust-the-process/
-topics: Business, Entrepreneurship
+topics: Entrepreneurship,Innovation Process
 offered_by: The Martin Trust Center for MIT Entrepreneurship
 website: https://entrepreneurship.mit.edu/podcast/
 apple_podcasts_url: https://podcasts.apple.com/us/podcast/trust-the-process-mit


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

closes https://github.com/mitodl/hq/issues/5630

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Updates all the podcast topics to use MIT Learn subtopics -- two per podcast series
- I tried to limit the topics to two subtopics each, but there were a couple of series that could only be matched to a top-level topic. For example, it was too hard to choose subtopics for the the MIT Technology Review podcast 

